### PR TITLE
Add fix for frontend Dockerfile to use npm instead of yarn

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,16 +5,15 @@ RUN mkdir -p /usr/src/app/next
 WORKDIR /usr/src/app/next
 
 COPY package*.json ./
-COPY yarn.lock ./
 
-RUN yarn install
+RUN npm install
 
 COPY . .
 
-RUN yarn build
+RUN npm run build
 
 RUN ls
 
 EXPOSE 3000
 
-CMD [ "yarn", "start" ]
+CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
- Replace yarn with npm in the frontend Dockerfile to fix yarn.lock related build issues